### PR TITLE
Added a new method that allows extraction of animated gifs with no animation flag within the metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 requests
+pillow
+bs4
+apnggif

--- a/sticker_dl.py
+++ b/sticker_dl.py
@@ -12,7 +12,6 @@ import json
 
 def main():
     pack_ext = ""
-    flag = 0
     if len(sys.argv) > 1:
         pack_id = int(sys.argv[1])
         if len(sys.argv) > 2:


### PR DESCRIPTION
Example link: https://store.line.me/stickershop/product/18628470/en
Meta data shows there is no animation available.


New method parses the html on the page to parse the link stored in the html element to extract the apng. The apng is then converted to gif using the pillow library.

Here's a demo:
![demo](https://github.com/doubleplusc/Line-sticker-downloader/assets/78403245/5eb01fc2-dc05-43d3-8792-8799eefb3195)
